### PR TITLE
Can we change the URL names to match the pages;

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -33,14 +33,14 @@
         >
           <%= link_to 'Data portal', data_portal_path, data: { turbolinks: false } %>
         </li>
-    		<li class="nav-item <% if current_page?(insights_path) || controller.controller_name == 'insights' %> -current <% end%>">
-          <%= link_to 'Insights', insights_path, data: { turbolinks: false } %>
+    		<li class="nav-item <% if current_page?(hub_path) || controller.controller_name == 'insights' %> -current <% end%>">
+          <%= link_to 'Insights', hub_path, data: { turbolinks: false } %>
         </li>
-        <li class="nav-item <% if current_page?(initiatives_path) || controller.controller_name == 'initiatives' %> -current <% end%>">
-          <%= link_to 'Programmes', initiatives_path, data: { turbolinks: false } %>
+        <li class="nav-item <% if current_page?(work_path) || controller.controller_name == 'initiatives' %> -current <% end%>">
+          <%= link_to 'Programmes', work_path, data: { turbolinks: false } %>
         </li>
-        <li class="nav-item <% if current_page?(tools_path) %> -current <% end%>">
-          <%= link_to 'Tools', tools_path, data: { turbolinks: false } %>
+        <li class="nav-item <% if current_page?(terms_of_reference_path) %> -current <% end%>">
+          <%= link_to 'Tools', terms_of_reference_path, data: { turbolinks: false } %>
         </li>
     		<li class="nav-item <% if current_page?(about_path) %> -current <% end%>">
           <%= link_to 'About FMT', about_path, data: { turbolinks: false } %>

--- a/app/views/shared/_mobile-menu.html.erb
+++ b/app/views/shared/_mobile-menu.html.erb
@@ -9,14 +9,14 @@
           <li class="nav-item <% if controller.controller_name == 'data_portal' || controller.controller_name == 'report' %> -current <% end%>">
             <%= link_to 'Data portal', data_portal_path %>
           </li>
-          <li class="nav-item <% if current_page?(insights_path) %> -current <% end%>">
-            <%= link_to 'Knowledge hub', insights_path %>
+          <li class="nav-item <% if current_page?(hub_path) %> -current <% end%>">
+            <%= link_to 'Knowledge hub', hub_path %>
           </li>
-          <li class="nav-item <% if current_page?(initiatives_path) %> -current <% end%>">
-            <%= link_to 'Our work', initiatives_path %>
+          <li class="nav-item <% if current_page?(work_path) %> -current <% end%>">
+            <%= link_to 'Our work', work_path %>
           </li>
-          <li class="nav-item <% if current_page?(tools_path) %> -current <% end%>">
-            <%= link_to 'Terms of reference', tools_path %>
+          <li class="nav-item <% if current_page?(terms_of_reference_path) %> -current <% end%>">
+            <%= link_to 'Terms of reference', terms_of_reference_path %>
           </li>
           <li class="nav-item <% if current_page?(about_path) %> -current <% end%>">
             <%= link_to 'About FMT', about_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,7 @@ Rails.application.routes.draw do
   end
 
   # Insights
-  get 'hubn/:category/:slug', to: 'insights#show', as: 'insights_show'
+  get 'hub/:category/:slug', to: 'insights#show', as: 'insights_show'
   get 'hub/:category', to: 'insights#categories', as: 'insights_filter_index'
   get 'hub', to: 'insights#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,17 +89,17 @@ Rails.application.routes.draw do
   end
 
   # Insights
-  get 'insights/:category/:slug', to: 'insights#show', as: 'insights_show'
-  get 'insights/:category', to: 'insights#categories', as: 'insights_filter_index'
-  get 'insights', to: 'insights#index'
+  get 'hubn/:category/:slug', to: 'insights#show', as: 'insights_show'
+  get 'hub/:category', to: 'insights#categories', as: 'insights_filter_index'
+  get 'hub', to: 'insights#index'
 
   # Initiatives
-  get 'initiatives/:tag/:slug', to: 'initiatives#show', as: 'initiatives_show'
-  get 'initiatives/:tag', to: 'initiatives#filter_index', as: 'initiatives_filter_index'
-  get 'initiatives', to: 'initiatives#index'
+  get 'work/:tag/:slug', to: 'initiatives#show', as: 'initiatives_show'
+  get 'work/:tag', to: 'initiatives#filter_index', as: 'initiatives_filter_index'
+  get 'work', to: 'initiatives#index'
 
   # Tools
-  get 'tools' => 'tools#index'
+  get 'terms-of-reference' => 'tools#index'
 
   namespace :fdapi do
     resources :household_transactions, only: [:index, :show]


### PR DESCRIPTION
The Knowledge hub page needs to be hub, not insights
Our work page needs to be work, not initiatives
Terms of Reference page needs to be terms-of-reference, not tools
